### PR TITLE
TIG-1203: Make {Workload,Actor,Phase}Context types hierarchical

### DIFF
--- a/src/gennylib/include/gennylib/ConfigNode.hpp
+++ b/src/gennylib/include/gennylib/ConfigNode.hpp
@@ -1,0 +1,208 @@
+#ifndef HEADER_F4822E1D_5AE5_4A00_B6BF_F26F05C1AC55_INCLUDED
+#define HEADER_F4822E1D_5AE5_4A00_B6BF_F26F05C1AC55_INCLUDED
+
+#include <functional>
+#include <iterator>
+#include <optional>
+#include <type_traits>
+#include <vector>
+
+#include <yaml-cpp/yaml.h>
+
+#include <gennylib/InvalidConfigurationException.hpp>
+
+namespace genny::V1 {
+
+/**
+ * If Required, type is Out, else it's optional<Out>
+ */
+template <class Out, bool Required>
+using MaybeOptionalT = typename std::conditional<Required, Out, std::optional<Out>>::type;
+
+/**
+ * The "path" to a configured value. E.g. given the structure
+ *
+ * ```yaml
+ * foo:
+ *   bar:
+ *     baz: [10,20,30]
+ * ```
+ *
+ * The path to the 10 is "foo/bar/baz/0".
+ *
+ * This is used to report meaningful exceptions in the case of mis-configuration.
+ */
+class ConfigPath {
+public:
+    using value_type = std::function<void(std::ostream&)>;
+
+    ConfigPath() = default;
+
+    ConfigPath(ConfigPath&) = delete;
+    void operator=(ConfigPath&) = delete;
+
+    void add(const value_type& elt) {
+        _elements.push_back(elt);
+    }
+
+    auto begin() const {
+        return std::begin(_elements);
+    }
+
+    auto end() const {
+        return std::end(_elements);
+    }
+
+private:
+    /**
+     * The parts of the path, so for this structure
+     *
+     * ```yaml
+     * foo:
+     *   bar: [bat, baz]
+     * ```
+     *
+     * If this `ConfigPath` represents "baz", then `_elements`
+     * will be `["foo", "bar", 1]`.
+     *
+     * To be "efficient" we only store a `function` that produces the
+     * path component string; do this to avoid (maybe) expensive
+     * string-formatting in the "happy case" where the ConfigPath is
+     * never fully serialized to an exception.
+     */
+    std::vector<value_type> _elements;
+};
+
+// Support putting ConfigPaths onto ostreams
+inline std::ostream& operator<<(std::ostream& out, const ConfigPath& path) {
+    for (const auto& f : path) {
+        f(out);
+        out << "/";
+    }
+    return out;
+}
+
+class ConfigNode {
+public:
+    ConfigNode(YAML::Node node, const ConfigNode* delegateNode = nullptr)
+        : _node(std::move(node)), _delegateNode(delegateNode) {}
+
+    /**
+     * Retrieve configuration values from the top-level `_node` configuration.
+     * Returns `_node[arg1][arg2]...[argN]`.
+     *
+     * @tparam Out the output type required. Will forward to `YAML::Node.as<Out>()`
+     * @tparam Required If true, will error if item not found. If false, will return an
+     * `std::optional<Out>` that will be empty if not found.
+     */
+    template <class Out = YAML::Node, bool Required = true, class... Args>
+    MaybeOptionalT<Out, Required> get_noinherit(Args&&... args) const {
+        ConfigPath path;
+        auto node = get_helper<Required>(path, _node, std::forward<Args>(args)...);
+
+        if (!node.IsDefined()) {
+            if constexpr (Required) {
+                std::stringstream error;
+                error << "Invalid key at path [" << path << "]";
+                throw InvalidConfigurationException(error.str());
+            } else {
+                return std::nullopt;
+            }
+        }
+
+        try {
+            if constexpr (Required) {
+                return node.template as<Out>();
+            } else {
+                return std::make_optional<Out>(node.template as<Out>());
+            }
+        } catch (const YAML::BadConversion& conv) {
+            std::stringstream error;
+            // typeid(Out).name() is kinda hokey but could be useful when debugging config issues.
+            error << "Bad conversion of [" << node << "] to [" << typeid(Out).name() << "] "
+                  << "at path [" << path << "]: " << conv.what();
+            throw InvalidConfigurationException(error.str());
+        }
+    };
+
+    /**
+     * Retrieve configuration values from an inner `_node` configuration.
+     * If `_node[arg1][arg2]...[argN]` isn't specified directly, then the value from
+     * `_delegateNode.get(arg1, arg2, ..., argN)` is used, if present.
+     *
+     * @tparam Out the output type required. Will forward to `YAML::Node.as<Out>()`
+     * @tparam Required If true, will error if item not found. If false, will return an
+     * `std::optional<Out>` that will be empty if not found.
+     */
+    template <typename Out = YAML::Node, bool Required = true, class... Args>
+    MaybeOptionalT<Out, Required> get(Args&&... args) const {
+        if (!this->_delegateNode) {
+            return get_noinherit<Out, Required>(std::forward<Args>(args)...);
+        }
+
+        // try to extract from own node
+        auto fromSelf = get_noinherit<Out, false>(std::forward<Args>(args)...);
+        if (fromSelf) {
+            if constexpr (Required) {
+                // unwrap from optional<T>
+                return *fromSelf;
+            } else {
+                // don't unwrap, return the optional<T> itself
+                return fromSelf;
+            }
+        }
+
+        // fallback to delegate node
+        return this->_delegateNode->template get<Out, Required>(std::forward<Args>(args)...);
+    };
+
+protected:
+    const YAML::Node _node;
+
+private:
+    // This is the base-case when we're out of Args... expansions in the other helper below
+    template <bool Required>
+    static YAML::Node get_helper(const ConfigPath& parent, const YAML::Node& curr) {
+        return curr;
+    }
+
+    // Recursive case where we pick off first item and recurse:
+    //      get_helper(foo, a, b, c) // this fn
+    //   -> get_helper(foo[a], b, c) // this fn
+    //   -> get_helper(foo[a][b], c) // this fn
+    //   -> get_helper(foo[a][b][c]) // "base case" fn above
+    template <bool Required, class PathFirst, class... PathRest>
+    static YAML::Node get_helper(ConfigPath& parent,
+                                 const YAML::Node& curr,
+                                 PathFirst&& pathFirst,
+                                 PathRest&&... rest) {
+        if (curr.IsScalar()) {
+            std::stringstream error;
+            error << "Wanted [" << parent << pathFirst << "] but [" << parent << "] is scalar: ["
+                  << curr << "]";
+            throw InvalidConfigurationException(error.str());
+        }
+
+        const auto& next = curr[std::forward<PathFirst>(pathFirst)];
+        parent.add([&](std::ostream& out) { out << pathFirst; });
+
+        if (!next.IsDefined()) {
+            if constexpr (Required) {
+                std::stringstream error;
+                error << "Invalid key [" << pathFirst << "] at path [" << parent
+                      << "]. Last accessed [" << curr << "].";
+                throw InvalidConfigurationException(error.str());
+            } else {
+                return next;
+            }
+        }
+
+        return get_helper<Required>(parent, next, std::forward<PathRest>(rest)...);
+    }
+
+    const ConfigNode* _delegateNode;
+};
+
+}  // namespace genny::V1
+
+#endif  // HEADER_F4822E1D_5AE5_4A00_B6BF_F26F05C1AC55_INCLUDED

--- a/src/gennylib/include/gennylib/context.hpp
+++ b/src/gennylib/include/gennylib/context.hpp
@@ -2,13 +2,9 @@
 #define HEADER_0E802987_B910_4661_8FAB_8B952A1E453B_INCLUDED
 
 #include <cassert>
-#include <functional>
-#include <iterator>
 #include <map>
 #include <memory>
-#include <optional>
 #include <string>
-#include <type_traits>
 #include <vector>
 
 #include <boost/noncopyable.hpp>
@@ -21,6 +17,7 @@
 #include <gennylib/ActorProducer.hpp>
 #include <gennylib/ActorVector.hpp>
 #include <gennylib/Cast.hpp>
+#include <gennylib/ConfigNode.hpp>
 #include <gennylib/DefaultRandom.hpp>
 #include <gennylib/InvalidConfigurationException.hpp>
 #include <gennylib/Orchestrator.hpp>
@@ -35,164 +32,48 @@
  *
  * Please see the documentation below on WorkloadContext, ActorContext, and PhaseContext.
  */
-
-
-/*
- * This is all helper/private implementation details. Ideally this section could
- * be defined _below_ the important stuff, but we live in a cruel world.
- */
-namespace genny::V1 {
-
-/**
- * If Required, type is Out, else it's optional<Out>
- */
-template <class Out, bool Required = true>
-struct MaybeOptional {
-    using type = typename std::conditional<Required, Out, std::optional<Out>>::type;
-};
-
-/**
- * The "path" to a configured value. E.g. given the structure
- *
- * ```yaml
- * foo:
- *   bar:
- *     baz: [10,20,30]
- * ```
- *
- * The path to the 10 is "foo/bar/baz/0".
- *
- * This is used to report meaningful exceptions in the case of mis-configuration.
- */
-class ConfigPath {
-
-public:
-    ConfigPath() = default;
-
-    ConfigPath(ConfigPath&) = delete;
-    void operator=(ConfigPath&) = delete;
-
-    template <class T>
-    void add(const T& elt) {
-        _elements.push_back(elt);
-    }
-    auto begin() const {
-        return std::begin(_elements);
-    }
-    auto end() const {
-        return std::end(_elements);
-    }
-
-private:
-    /**
-     * The parts of the path, so for this structure
-     *
-     * ```yaml
-     * foo:
-     *   bar: [bat, baz]
-     * ```
-     *
-     * If this `ConfigPath` represents "baz", then `_elements`
-     * will be `["foo", "bar", 1]`.
-     *
-     * To be "efficient" we only store a `function` that produces the
-     * path component string; do this to avoid (maybe) expensive
-     * string-formatting in the "happy case" where the ConfigPath is
-     * never fully serialized to an exception.
-     */
-    std::vector<std::function<void(std::ostream&)>> _elements;
-};
-
-// Support putting ConfigPaths onto ostreams
-inline std::ostream& operator<<(std::ostream& out, const ConfigPath& path) {
-    for (const auto& f : path) {
-        f(out);
-        out << "/";
-    }
-    return out;
-}
-
-// Used by get() in WorkloadContext and ActorContext
-//
-// This is the base-case when we're out of Args... expansions in the other helper below
-template <class Out,
-          class Current,
-          bool Required = true,
-          class OutV = typename MaybeOptional<Out, Required>::type>
-OutV get_helper(const ConfigPath& parent, const Current& curr) {
-    if (!curr) {
-        if constexpr (Required) {
-            std::stringstream error;
-            error << "Invalid key at path [" << parent << "]";
-            throw InvalidConfigurationException(error.str());
-        } else {
-            return std::nullopt;
-        }
-    }
-    try {
-        if constexpr (Required) {
-            return curr.template as<Out>();
-        } else {
-            return std::make_optional<Out>(curr.template as<Out>());
-        }
-    } catch (const YAML::BadConversion& conv) {
-        std::stringstream error;
-        // typeid(Out).name() is kinda hokey but could be useful when debugging config issues.
-        error << "Bad conversion of [" << curr << "] to [" << typeid(Out).name() << "] "
-              << "at path [" << parent << "]: " << conv.what();
-        throw InvalidConfigurationException(error.str());
-    }
-}
-
-// Used by get() in WorkloadContext and ActorContext
-//
-// Recursive case where we pick off first item and recurse:
-//      get_helper(foo, a, b, c) // this fn
-//   -> get_helper(foo[a], b, c) // this fn
-//   -> get_helper(foo[a][b], c) // this fn
-//   -> get_helper(foo[a][b][c]) // "base case" fn above
-template <class Out,
-          class Current,
-          bool Required = true,
-          class OutV = typename MaybeOptional<Out, Required>::type,
-          class PathFirst,
-          class... PathRest>
-OutV get_helper(ConfigPath& parent,
-                const Current& curr,
-                PathFirst&& pathFirst,
-                PathRest&&... rest) {
-    if (curr.IsScalar()) {
-        std::stringstream error;
-        error << "Wanted [" << parent << pathFirst << "] but [" << parent << "] is scalar: ["
-              << curr << "]";
-        throw InvalidConfigurationException(error.str());
-    }
-    const auto& next = curr[std::forward<PathFirst>(pathFirst)];
-
-    parent.add([&](std::ostream& out) { out << pathFirst; });
-
-    if (!next.IsDefined()) {
-        if constexpr (Required) {
-            std::stringstream error;
-            error << "Invalid key [" << pathFirst << "] at path [" << parent << "]. Last accessed ["
-                  << curr << "].";
-            throw InvalidConfigurationException(error.str());
-        } else {
-            return std::nullopt;
-        }
-    }
-    return V1::get_helper<Out, Current, Required>(parent, next, std::forward<PathRest>(rest)...);
-}
-
-}  // namespace genny::V1
-
 namespace genny {
 
 /**
  * Represents the top-level/"global" configuration and context for configuring actors.
  * Call `.get()` to access top-level yaml configs.
+ *
+ * The get() method is somewhat expensive and should only be called during actor/workload setup.
+ *
+ * Typical usage:
+ *
+ * ```c++
+ *     class MyActor ... {
+ *       string name;
+ *       MyActor(ActorContext& context)
+ *       : name{context.get<string>("Name")} {}
+ *     }
+ * ```
+ *
+ * Given this %YAML:
+ *
+ * ```yaml
+ *     SchemaVersion: 2018-07-01
+ *     Actors:
+ *     - Name: Foo
+ *       Count: 100
+ *     - Name: Bar
+ * ```
+ *
+ * Then traverse as with the following:
+ *
+ * ```c++
+ *     auto schema = context.get<std::string>("SchemaVersion");
+ *     auto actors = context.get("Actors"); // actors is a YAML::Node
+ *     auto name0  = context.get<std::string>("Actors", 0, "Name");
+ *     auto count0 = context.get<int>("Actors", 0, "Count");
+ *     auto name1  = context.get<std::string>("Actors", 1, "Name");
+ *
+ *     // if value may not exist:
+ *     std::optional<int> maybeInt = context.get<int,false>("Actors", 0, "Count");
+ * ```
  */
-class WorkloadContext {
+class WorkloadContext : public V1::ConfigNode {
 public:
     /**
      * @param node top-level (file-level) YAML node
@@ -213,68 +94,6 @@ public:
     void operator=(WorkloadContext&) = delete;
     WorkloadContext(WorkloadContext&&) = default;
     void operator=(WorkloadContext&&) = delete;
-
-    /**
-     * Retrieve configuration values from the top-level workload configuration.
-     * Returns `root[arg1][arg2]...[argN]`.
-     *
-     * This is somewhat expensive and should only be called during actor/workload setup.
-     *
-     * Typical usage:
-     *
-     * ```c++
-     *     class MyActor ... {
-     *       string name;
-     *       MyActor(ActorContext& context)
-     *       : name{context.get<string>("Name")} {}
-     *     }
-     * ```
-     *
-     * Given this %YAML:
-     *
-     * ```yaml
-     *     SchemaVersion: 2018-07-01
-     *     Actors:
-     *     - Name: Foo
-     *       Count: 100
-     *     - Name: Bar
-     * ```
-     *
-     * Then traverse as with the following:
-     *
-     * ```c++
-     *     auto schema = context.get<std::string>("SchemaVersion");
-     *     auto actors = context.get("Actors"); // actors is a YAML::Node
-     *     auto name0  = context.get<std::string>("Actors", 0, "Name");
-     *     auto count0 = context.get<int>("Actors", 0, "Count");
-     *     auto name1  = context.get<std::string>("Actors", 1, "Name");
-     *
-     *     // if value may not exist:
-     *     std::optional<int> = context.get<int,false>("Actors", 0, "Count");
-     * ```
-     * @tparam T the output type required. Will forward to `YAML::Node.as<T>()`
-     * @tparam Required If true, will error if item not found. If false, will return an
-     * `std::optional<T>` that will be empty if not found.
-     */
-    template <class T = YAML::Node,
-              bool Required = true,
-              class OutV = typename V1::MaybeOptional<T, Required>::type,
-              class... Args>
-    static OutV get_static(const YAML::Node& node, Args&&... args) {
-        V1::ConfigPath p;
-        return V1::get_helper<T, YAML::Node, Required>(p, node, std::forward<Args>(args)...);
-    };
-
-    /**
-     * @see get_static()
-     */
-    template <typename T = YAML::Node,
-              bool Required = true,
-              class OutV = typename V1::MaybeOptional<T, Required>::type,
-              class... Args>
-    OutV get(Args&&... args) const {
-        return WorkloadContext::get_static<T, Required>(_node, std::forward<Args>(args)...);
-    };
 
     /**
      * @return all the actors produced. This should only be called by workload drivers.
@@ -338,7 +157,6 @@ private:
     // helper methods used during construction
     static ActorVector _constructActors(const Cast& cast,
                                         const std::unique_ptr<ActorContext>& contexts);
-    YAML::Node _node;
 
     metrics::Registry* const _registry;
     Orchestrator* const _orchestrator;
@@ -364,12 +182,41 @@ class PhaseContext;
 
 /**
  * Represents each `Actor:` block within a WorkloadConfig.
+ *
+ * The get() method is somewhat expensive and should only be called during actor/workload setup.
+ *
+ * Typical usage:
+ *
+ * ```c++
+ *     class MyActor ... {
+ *       string name;
+ *       MyActor(ActorContext& context)
+ *       : name{context.get<string>("Name")} {}
+ *     }
+ * ```
+ *
+ * Given this %YAML:
+ *
+ * ```yaml
+ *     SchemaVersion: 2018-07-01
+ *     Actors:
+ *     - Name: Foo
+ *     - Name: Bar
+ * ```
+ *
+ * There will be two ActorConfigs, one for `{Name: Foo}` and another for `{Name: Bar}`.
+ *
+ * ```c++
+ * auto name = cx.get<std::string>("Name");
+ * ```
  */
-class ActorContext final {
+class ActorContext final : public V1::ConfigNode {
 public:
-    ActorContext(const YAML::Node& node, WorkloadContext& workloadContext)
-        : _node{node}, _workload{&workloadContext}, _phaseContexts{} {
-        _phaseContexts = constructPhaseContexts(node, this);
+    ActorContext(YAML::Node node, WorkloadContext& workloadContext)
+        : ConfigNode(std::move(node), std::addressof(workloadContext)),
+          _workload{&workloadContext},
+          _phaseContexts{} {
+        _phaseContexts = constructPhaseContexts(_node, this);
     }
 
     // no copy or move
@@ -377,50 +224,6 @@ public:
     void operator=(ActorContext&) = delete;
     ActorContext(ActorContext&&) = default;
     void operator=(ActorContext&&) = delete;
-
-    /**
-     * Retrieve configuration values from a particular `Actor:` block in the workload configuration.
-     * `Returns actor[arg1][arg2]...[argN]`.
-     *
-     * This is somewhat expensive and should only be called during actor/workload setup.
-     *
-     * Typical usage:
-     *
-     * ```c++
-     *     class MyActor ... {
-     *       string name;
-     *       MyActor(ActorContext& context)
-     *       : name{context.get<string>("Name")} {}
-     *     }
-     * ```
-     *
-     * Given this %YAML:
-     *
-     * ```yaml
-     *     SchemaVersion: 2018-07-01
-     *     Actors:
-     *     - Name: Foo
-     *     - Name: Bar
-     * ```
-     *
-     * There will be two ActorConfigs, one for `{Name:Foo}` and another for `{Name:Bar}`.
-     *
-     * ```
-     * auto name = cx.get<std::string>("Name");
-     * ```
-     * @tparam T the return-value type. Will return a T if Required (and throw if not found) else
-     * will return an optional<T> (empty optional if not found).
-     * @tparam Required If true, will error if item not found. If false, will return an optional<T>
-     * that will be empty if not found.
-     */
-    template <typename T = YAML::Node,
-              bool Required = true,
-              class OutV = typename V1::MaybeOptional<T, Required>::type,
-              class... Args>
-    OutV get(Args&&... args) const {
-        V1::ConfigPath p;
-        return V1::get_helper<T, YAML::Node, Required>(p, _node, std::forward<Args>(args)...);
-    };
 
     /**
      * @return top-level workload configuration
@@ -601,50 +404,22 @@ private:
 
     static std::unordered_map<genny::PhaseNumber, std::unique_ptr<PhaseContext>>
     constructPhaseContexts(const YAML::Node&, ActorContext*);
-    YAML::Node _node;
     WorkloadContext* _workload;
     std::unordered_map<PhaseNumber, std::unique_ptr<PhaseContext>> _phaseContexts;
 };
 
 
-class PhaseContext final {
+class PhaseContext final : public V1::ConfigNode {
 
 public:
-    PhaseContext(const YAML::Node& node, const ActorContext& actorContext)
-        : _node{node}, _actor{&actorContext} {}
+    PhaseContext(YAML::Node node, const ActorContext& actorContext)
+        : ConfigNode(std::move(node), std::addressof(actorContext)) {}
 
     // no copy or move
     PhaseContext(PhaseContext&) = delete;
     void operator=(PhaseContext&) = delete;
     PhaseContext(PhaseContext&&) = default;
     void operator=(PhaseContext&&) = delete;
-
-    /**
-     * @return the value associated with the given key. If not specified
-     * directly in this `Phases` block, then the value from the parent `Actor`
-     * context is used, if present.
-     */
-    template <typename T = YAML::Node,
-              bool Required = true,
-              class OutV = typename V1::MaybeOptional<T, Required>::type,
-              class... Args>
-    OutV get(Args&&... args) const {
-        V1::ConfigPath p;
-        // try to extract from own node
-        auto fromSelf = V1::get_helper<T, YAML::Node, false>(p, _node, std::forward<Args>(args)...);
-        if (fromSelf) {
-            if constexpr (Required) {
-                // unwrap from optional<T>
-                return *fromSelf;
-            } else {
-                // don't unwrap, return the optional<T> itself
-                return fromSelf;
-            }
-        }
-
-        // fallback to actor node
-        return this->_actor->get<T, Required>(std::forward<Args>(args)...);
-    };
 
     /**
      * Called in PhaseLoop during the IterationCompletionCheck constructor.
@@ -665,7 +440,6 @@ private:
     bool _isNop() const;
 
 private:
-    YAML::Node _node;
     const ActorContext* _actor;
 };
 

--- a/src/gennylib/src/context.cpp
+++ b/src/gennylib/src/context.cpp
@@ -17,10 +17,10 @@ WorkloadContext::WorkloadContext(YAML::Node node,
                                  Orchestrator& orchestrator,
                                  const std::string& mongoUri,
                                  const Cast& cast)
-    : _node{std::move(node)}, _registry{&registry}, _orchestrator{&orchestrator} {
+    : V1::ConfigNode(std::move(node)), _registry{&registry}, _orchestrator{&orchestrator} {
     // This is good enough for now. Later can add a WorkloadContextValidator concept
     // and wire in a vector of those similar to how we do with the vector of Producers.
-    if (get_static<std::string>(_node, "SchemaVersion") != "2018-07-01") {
+    if (this->get_noinherit<std::string>("SchemaVersion") != "2018-07-01") {
         throw InvalidConfigurationException("Invalid schema version");
     }
 
@@ -31,13 +31,13 @@ WorkloadContext::WorkloadContext(YAML::Node node,
     auto poolFactory = PoolFactory(mongoUri);
 
     auto queryOpts =
-        get_static<std::map<std::string, std::string>, false>(node, "Pool", "QueryOptions");
+        this->get_noinherit<std::map<std::string, std::string>, false>("Pool", "QueryOptions");
     if (queryOpts) {
         poolFactory.setOptions(PoolFactory::kQueryOption, *queryOpts);
     }
 
     auto accessOpts =
-        get_static<std::map<std::string, std::string>, false>(node, "Pool", "AccessOptions");
+        this->get_noinherit<std::map<std::string, std::string>, false>("Pool", "AccessOptions");
     if (accessOpts) {
         poolFactory.setOptions(PoolFactory::kAccessOption, *accessOpts);
     }
@@ -45,13 +45,13 @@ WorkloadContext::WorkloadContext(YAML::Node node,
     _clientPool = poolFactory.makePool();
 
     // Make a bunch of actor contexts
-    for (const auto& actor : get_static(node, "Actors")) {
+    for (const auto& actor : this->get_noinherit("Actors")) {
         _actorContexts.emplace_back(std::make_unique<genny::ActorContext>(actor, *this));
     }
 
     // Default value selected from random.org, by selecting 2 random numbers
     // between 1 and 10^9 and concatenating.
-    _rng.seed(get_static<int, false>(node, "RandomSeed").value_or(269849313357703264));
+    _rng.seed(this->get_noinherit<int, false>("RandomSeed").value_or(269849313357703264));
 
     for (auto& actorContext : _actorContexts) {
         for (auto&& actor : _constructActors(cast, actorContext)) {

--- a/src/gennylib/test/context_test.cpp
+++ b/src/gennylib/test/context_test.cpp
@@ -447,3 +447,175 @@ TEST_CASE("Actors Share WorkloadContext State") {
     REQUIRE(WorkloadContext::getActorSharedState<DummyInsert, DummyInsert::InsertCounter>() ==
             10 * 10);
 }
+
+TEST_CASE("Configuration cascades to nested context types") {
+    auto yaml = YAML::Load(R"(
+SchemaVersion: 2018-07-01
+Database: test
+Actors:
+- Name: Actor1
+  Type: Op
+  Collection: mycoll
+  Phases:
+  - Operation: Nop
+
+  - Operation: Insert
+    Database: test3
+    Collection: mycoll2
+
+- Name: Actor2
+  Type: Op
+  Database: test2
+    )");
+
+    SECTION("ActorContext inherits from WorkloadContext") {
+        onContext(yaml, [](ActorContext& actorContext) {
+            const auto& workloadContext = actorContext.workload();
+            REQUIRE(workloadContext.get_noinherit<std::string>("Database") == "test");
+            REQUIRE(workloadContext.get<std::string>("Database") == "test");
+
+            const auto actorName = actorContext.get_noinherit<std::string>("Name");
+            REQUIRE((actorName == "Actor1" || actorName == "Actor2"));
+
+            if (actorName == "Actor1") {
+                REQUIRE(actorContext.get_noinherit<std::string, false>("Database") == std::nullopt);
+
+                REQUIRE_THROWS_WITH(
+                    ([&]() { actorContext.get_noinherit<std::string, true>("Database"); })(),
+                    Matches(R"(Invalid key \[Database\] at path(.*\n*)*))"));
+
+                REQUIRE(actorContext.get<std::string>("Database") == "test");
+            } else if (actorName == "Actor2") {
+                REQUIRE(actorContext.get_noinherit<std::string>("Database") == "test2");
+                REQUIRE(actorContext.get<std::string>("Database") == "test2");
+            }
+        });
+    }
+
+    SECTION("PhaseContext inherits from ActorContext") {
+        onContext(yaml, [](ActorContext& actorContext) {
+            const auto actorName = actorContext.get_noinherit<std::string>("Name");
+            REQUIRE((actorName == "Actor1" || actorName == "Actor2"));
+
+            if (actorName == "Actor1") {
+                REQUIRE(actorContext.get_noinherit<std::string>("Collection") == "mycoll");
+                REQUIRE(actorContext.get<std::string>("Collection") == "mycoll");
+
+                for (auto&& [phase, config] : actorContext.phases()) {
+                    REQUIRE((phase == 0 || phase == 1));
+
+                    if (phase == 0) {
+                        REQUIRE(config->get_noinherit<std::string, false>("Collection") ==
+                                std::nullopt);
+
+                        const auto* rawConfig = config.get();
+                        REQUIRE_THROWS_WITH(
+                            ([&]() {
+                                rawConfig->get_noinherit<std::string, true>("Collection");
+                            })(),
+                            Matches(R"(Invalid key \[Collection\] at path(.*\n*)*))"));
+
+                        REQUIRE(config->get<std::string>("Collection") == "mycoll");
+                    } else if (phase == 1) {
+                        REQUIRE(config->get_noinherit<std::string>("Collection") == "mycoll2");
+                        REQUIRE(config->get<std::string>("Collection") == "mycoll2");
+                    }
+                }
+            }
+        });
+    }
+
+    SECTION("PhaseContext inherits from WorkloadContext transitively") {
+        onContext(yaml, [](ActorContext& actorContext) {
+            const auto actorName = actorContext.get_noinherit<std::string>("Name");
+            REQUIRE((actorName == "Actor1" || actorName == "Actor2"));
+
+            if (actorName == "Actor1") {
+                for (auto&& [phase, config] : actorContext.phases()) {
+                    REQUIRE((phase == 0 || phase == 1));
+
+                    if (phase == 0) {
+                        REQUIRE(config->get_noinherit<std::string, false>("Database") ==
+                                std::nullopt);
+
+                        const auto* rawConfig = config.get();
+                        REQUIRE_THROWS_WITH(
+                            ([&]() { rawConfig->get_noinherit<std::string, true>("Database"); })(),
+                            Matches(R"(Invalid key \[Database\] at path(.*\n*)*))"));
+
+                        REQUIRE(config->get<std::string>("Database") == "test");
+                    } else if (phase == 1) {
+                        REQUIRE(config->get_noinherit<std::string>("Database") == "test3");
+                        REQUIRE(config->get<std::string>("Database") == "test3");
+                    }
+                }
+            }
+        });
+    }
+
+    SECTION("Nested contexts can have different types for the same named key") {
+        auto yaml = YAML::Load(R"(
+SchemaVersion: 2018-07-01
+MiscField: {a: b}
+Actors:
+- Name: Actor
+  Type: Op
+  MiscField: c
+  Phases:
+  - MiscField: [1, 2, 3]
+    )");
+
+        onContext(yaml, [](ActorContext& actorContext) {
+            const auto& workloadContext = actorContext.workload();
+
+            REQUIRE(workloadContext.get_noinherit<std::map<std::string, std::string>>(
+                        "MiscField") == std::map<std::string, std::string>{{"a", "b"}});
+            REQUIRE(workloadContext.get<std::map<std::string, std::string>>("MiscField") ==
+                    std::map<std::string, std::string>{{"a", "b"}});
+
+            const auto actorName = actorContext.get_noinherit<std::string>("Name");
+            REQUIRE(actorName == "Actor");
+
+            REQUIRE(actorContext.get_noinherit<std::string>("MiscField") == "c");
+            REQUIRE(actorContext.get<std::string>("MiscField") == "c");
+
+            REQUIRE_THROWS_WITH(
+                ([&]() {
+                    actorContext.get_noinherit<std::map<std::string, std::string>, true>(
+                        "MiscField");
+                })(),
+                Matches(R"(Bad conversion of \[c\] to(.*\n*)*))"));
+            REQUIRE_THROWS_WITH(([&]() {
+                                    actorContext.get<std::map<std::string, std::string>, true>(
+                                        "MiscField");
+                                })(),
+                                Matches(R"(Bad conversion of \[c\] to(.*\n*)*))"));
+
+            for (auto&& [phase, config] : actorContext.phases()) {
+                REQUIRE(phase == 0);
+
+                REQUIRE(config->get_noinherit<std::vector<int>>("MiscField") ==
+                        std::vector<int>{1, 2, 3});
+                REQUIRE(config->get<std::vector<int>>("MiscField") == std::vector<int>{1, 2, 3});
+
+                const auto* rawConfig = config.get();
+                REQUIRE_THROWS_WITH(
+                    ([&]() {
+                        rawConfig->get_noinherit<std::map<std::string, std::string>, true>(
+                            "MiscField");
+                    })(),
+                    Matches(R"(Bad conversion of \[\[1, 2, 3\]\] to(.*\n*)*))"));
+                REQUIRE_THROWS_WITH(([&]() {
+                                        rawConfig->get<std::map<std::string, std::string>, true>(
+                                            "MiscField");
+                                    })(),
+                                    Matches(R"(Bad conversion of \[\[1, 2, 3\]\] to(.*\n*)*))"));
+                REQUIRE_THROWS_WITH(
+                    ([&]() { rawConfig->get_noinherit<std::string, true>("MiscField"); })(),
+                    Matches(R"(Bad conversion of \[\[1, 2, 3\]\] to(.*\n*)*))"));
+                REQUIRE_THROWS_WITH(([&]() { rawConfig->get<std::string, true>("MiscField"); })(),
+                                    Matches(R"(Bad conversion of \[\[1, 2, 3\]\] to(.*\n*)*))"));
+            }
+        });
+    }
+}


### PR DESCRIPTION
Moves the logic in `PhaseContext` to inherit the configuration from `ActorContext` to a generic `ConfigNode` class.

----

I had taken a stab at [TIG-1187](https://jira.mongodb.org/browse/TIG-1187) and found myself defining an `OperationContext` class that mimicked the behavior of `PhaseContext::get()` to allow the user to save on some repetitive typing. My suspicion is that @jasonjhchan may want a similar construct as part of [TIG-1186](https://jira.mongodb.org/browse/TIG-1186) (e.g. for applying a write concern to all commands being executed).

**Note**: There isn't any urgency around doing a formal code review for these changes because I'll be out until December 18th. Although, if it seems like it'd be a useful point for Jason's changes to work off of, then someone can feel free to take it the rest of the way.

```cpp
// TODO: The genny::V1 namespace is meant to be private, so we may want to revisit the decision as
// outlined by TIG-1203 to put the ConfigNode class in it.
class OperationContext final : public V1::ConfigNode<PhaseContext> {
public:
    OperationContext(YAML::Node node, const PhaseContext& phaseContext)
        : ConfigNode(std::move(node), phaseContext) {}

    // no copy or move
    OperationContext(OperationContext&) = delete;
    void operator=(OperationContext&) = delete;
    OperationContext(OperationContext&&) = default;
    void operator=(OperationContext&&) = delete;
};

class Operation {
public:
    Operation(const OperationContext& operationContext, mongocxx::client& client)
        : _collection(client[operationContext.get<std::string>("Database")]
                            [operationContext.get<std::string>("Collection")]) {}

    virtual ~Operation() = default;
    virtual void run() = 0;

protected:
    mongocxx::collection _collection;
};

class InsertOne : public Operation {
public:
    InsertOne(const OperationContext& operationContext,
              mongocxx::client& client,
              std::mt19937_64& rng)
        : Operation(operationContext, client),
          _documentTemplate(value_generators::makeDoc(operationContext.get("Document"), rng)) {}

    void run() override {
        bsoncxx::builder::stream::document document{};
        auto view = _documentTemplate->view(document);
        BOOST_LOG_TRIVIAL(info) << " Inserting " << bsoncxx::to_json(view);
        _collection.insert_one(view);
    }

private:
    std::unique_ptr<value_generators::DocumentGenerator> _documentTemplate;
};
```